### PR TITLE
Fixed Unknown provider error with angular-animate dependency

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -17,7 +17,8 @@
   "jquery": "^2.2.0"
   <% } %>
 	<% if(includeAngular === true) { %>
-  "angular": "^1.5.3",
+  "angular": "^1.6.4",
+  "angular-animate": "^1.6.4",
   "angular-ui-router": "^0.3.0",
   "openmrs-contrib-uicommons": "^0.3.29"
   <% } %>

--- a/app/templates/webpack.config.js
+++ b/app/templates/webpack.config.js
@@ -163,7 +163,7 @@ var webpackConfig = {
 	  css: `${__dirname}/app/css/<%= appId %>.css`,
 	  vendor : [
 	        	<% if(includeJQuery === true) { %> 'jquery' <% } %>
-	        	<% if(includeAngular === true) { %> 'angular', 'openmrs-contrib-uicommons'<% } %>
+	        	<% if(includeAngular === true) { %> 'angular', 'openmrs-contrib-uicommons', 'angular-animate' <% } %>
                 <% if(includeReact === true) { %>
                     'react', 'react-router'
                     <% if(includeRedux === true) { %>


### PR DESCRIPTION
Fixed the "Unknown Provider Error" by adding angular-animate : "^1.6.4" dependency in the package.json file and also made the angular version to be inline with the angular-animate version. 